### PR TITLE
Update FetchComparator.java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
                             <!-- TODO all drivers from directory -->
                             <Class-Path>jdbc_drivers/mssql-jdbc-8.2.0.jre8.jar jdbc_drivers/mssql-jdbc-8.2.0.jre11.jar jdbc_drivers/mssql-jdbc-8.2.0.jre13.jar jdbc_drivers/tdgssconfig-4.jar
                                 jdbc_drivers/terajdbc-4.jar jdbc_drivers/mysql-connector-java-8.0.19.jar
-                                jdbc_drivers/postgresql-42.2.11.jar jdbc_drivers/mariadb-java-client-2.6.0.jar</Class-Path>
+                                jdbc_drivers/postgresql-42.2.11.jar jdbc_drivers/mariadb-java-client-2.6.0.jar jdbc_drivers/snowflake-jdbc-3.9.2.jar</Class-Path>
                         </manifestEntries>
                     </archive>
                     <descriptorRefs>

--- a/src/main/java/uk/co/objectivity/test/db/comparators/FetchComparator.java
+++ b/src/main/java/uk/co/objectivity/test/db/comparators/FetchComparator.java
@@ -100,10 +100,10 @@ public class FetchComparator extends Comparator {
             Sql sql1 = compare.getSqls().get(0);
             Sql sql2 = compare.getSqls().get(1);
 
-            stmt1 = connection1.prepareStatement(sql1.getSql(), ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet
+            stmt1 = connection1.prepareStatement(sql1.getSql(), ResultSet.TYPE_FORWARD_ONLY, ResultSet
                     .CONCUR_READ_ONLY);
             stmt1.setFetchSize(compare.getFetchSize());
-            stmt2 = connection2.prepareStatement(sql2.getSql(), ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet
+            stmt2 = connection2.prepareStatement(sql2.getSql(), ResultSet.TYPE_FORWARD_ONLY, ResultSet
                     .CONCUR_READ_ONLY);
             stmt2.setFetchSize(compare.getFetchSize());
 


### PR DESCRIPTION
Change from `TYPE_SCROLL_INSENSITIVE` to `TYPE_FORWARD_ONLY` ResultSet type. Fix problem with `java.lang.Exception: java.sql.SQLFeatureNotSupportedException: ResultSet type 1004 is not supported.` on Snowflake database.